### PR TITLE
Add meson build config

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,0 +1,28 @@
+project('reproc', 'c', version: '14.2.2')
+
+reproc_deps = []
+reproc_cargs = []
+if host_machine.system() == 'windows'
+    reproc_deps += meson.get_compiler('c').find_library('ws2_32')
+    reproc_cargs += '-DWIN32_LEAN_AND_MEAN'
+    platform = 'windows'
+else
+    platform = 'posix'
+    if host_machine.system() != 'darwin'
+        reproc_deps += meson.get_compiler('c').find_library('rt')
+    endif
+endif
+
+if get_option('multithreaded')
+    reproc_cargs += '-DREPROC_MULTITHREADED'
+    reproc_deps += dependency('threads')
+endif
+
+reproc_include = include_directories('reproc/include')
+
+subdir('reproc')
+if get_option('reproc-cpp')
+    add_languages('cpp')
+    reprocpp_include = include_directories('reproc++/include')
+    subdir('reproc++')
+endif

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,0 +1,3 @@
+option('multithreaded', type : 'boolean', value : true, description: 'Use pthread_sigmask and link against the system\'s thread library')
+option('reproc-cpp', type : 'boolean', value : true, description: 'Build C++ reproc')
+option('examples', type : 'boolean', value : true, description: 'Request build of the examples')

--- a/reproc++/examples/meson.build
+++ b/reproc++/examples/meson.build
@@ -1,0 +1,16 @@
+reprocpp_examples = ['drain', 'forward', 'run']
+
+if get_option('multithreaded')
+    reprocpp_examples += 'background'
+endif
+
+foreach example : reprocpp_examples
+    executable(example, example + '.cpp',
+        c_args: reproc_cargs + examples_cargs,
+        dependencies: reproc_deps,
+        link_with: [reproc_lib, reprocpp_lib],
+        include_directories: [reproc_include, reprocpp_include],
+        install: false
+    )
+endforeach
+

--- a/reproc++/meson.build
+++ b/reproc++/meson.build
@@ -1,0 +1,29 @@
+foreach header : ['arguments.hpp', 'drain.hpp', 'env.hpp', 'export.hpp', 'input.hpp', 'reproc.hpp', 'run.hpp']
+    install_headers('include/reproc++' / header, subdir: 'reproc++')
+endforeach
+
+reprocpp_src = 'src/reproc.cpp'
+
+reprocpp_lib = library('reproc++',
+    reprocpp_src,
+    cpp_args: reproc_cargs,
+    dependencies: reproc_deps,
+    link_with: reproc_lib,
+    include_directories: [reproc_include, reprocpp_include],
+    install: true
+)
+
+if get_option('examples')
+    subdir('examples')
+endif
+
+pkg = import('pkgconfig')
+
+pkg.generate(reprocpp_lib,
+    filebase : 'reproc++',
+    name : 'libreproc++',
+    version : meson.project_version(),
+    description : 'Cross-platform C99/C++11 process library',
+    url : 'https://github.com/DaanDeMeyer/reproc',
+)
+

--- a/reproc/examples/meson.build
+++ b/reproc/examples/meson.build
@@ -1,0 +1,11 @@
+examples_cargs = ['-DRESOURCE_DIRECTORY="../resources"']
+foreach example : ['drain', 'env', 'parent', 'path', 'poll', 'read', 'run']
+    executable(example, example + '.c',
+        c_args: reproc_cargs + examples_cargs,
+        dependencies: reproc_deps,
+        link_with: reproc_lib,
+        include_directories: reproc_include,
+        install: false
+    )
+endforeach
+

--- a/reproc/meson.build
+++ b/reproc/meson.build
@@ -1,0 +1,65 @@
+project('reproc', 'c', version: '14.2.2')
+
+reproc_deps = []
+reproc_cargs = []
+if host_machine.system() == 'windows'
+    reproc_deps += meson.get_compiler('c').find_library('ws2_32')
+    reproc_cargs += '-DWIN32_LEAN_AND_MEAN'
+    platform = 'windows'
+else
+    platform = 'posix'
+    if host_machine.system() != 'darwin'
+        reproc_deps += meson.get_compiler('c').find_library('rt')
+    endif
+endif
+
+if get_option('multithread')
+    reproc_cargs += '-DREPROC_MULTITHREADED'
+    reproc_deps += dependency('threads')
+endif
+
+reproc_include = include_directories('include')
+
+foreach header : ['drain.h', 'export.h', 'reproc.h', 'run.h']
+    install_headers('include/reproc' / header, subdir: 'reproc')
+endforeach
+
+reproc_src = [
+    'src/clock.' + platform + '.c',
+    'src/drain.c',
+    'src/error.' + platform + '.c',
+    'src/handle.' + platform + '.c',
+    'src/init.' + platform + '.c',
+    'src/options.c',
+    'src/pipe.' + platform + '.c',
+    'src/process.' + platform + '.c',
+    'src/redirect.' + platform + '.c',
+    'src/redirect.c',
+    'src/reproc.c',
+    'src/run.c',
+    'src/strv.c',
+    'src/utf.' + platform + '.c',
+]
+
+reproc_lib = library('reproc',
+    reproc_src,
+    c_args: reproc_cargs,
+    dependencies: reproc_deps,
+    include_directories: reproc_include,
+    install: true
+)
+
+if get_option('examples')
+    subdir('examples')
+endif
+
+pkg = import('pkgconfig')
+
+pkg.generate(reproc_lib,
+    filebase : 'reproc',
+    name : 'libreproc',
+    version : meson.project_version(),
+    description : 'Cross-platform C99/C++11 process library',
+    url : 'https://github.com/DaanDeMeyer/reproc',
+)
+

--- a/reproc/meson.build
+++ b/reproc/meson.build
@@ -1,25 +1,3 @@
-project('reproc', 'c', version: '14.2.2')
-
-reproc_deps = []
-reproc_cargs = []
-if host_machine.system() == 'windows'
-    reproc_deps += meson.get_compiler('c').find_library('ws2_32')
-    reproc_cargs += '-DWIN32_LEAN_AND_MEAN'
-    platform = 'windows'
-else
-    platform = 'posix'
-    if host_machine.system() != 'darwin'
-        reproc_deps += meson.get_compiler('c').find_library('rt')
-    endif
-endif
-
-if get_option('multithread')
-    reproc_cargs += '-DREPROC_MULTITHREADED'
-    reproc_deps += dependency('threads')
-endif
-
-reproc_include = include_directories('include')
-
 foreach header : ['drain.h', 'export.h', 'reproc.h', 'run.h']
     install_headers('include/reproc' / header, subdir: 'reproc')
 endforeach

--- a/reproc/meson.build
+++ b/reproc/meson.build
@@ -27,6 +27,12 @@ reproc_lib = library('reproc',
     install: true
 )
 
+reproc_dep = declare_dependency(
+    dependencies : reproc_deps,
+    include_directories : reproc_include,
+    link_with : reproc_lib,
+)
+
 if get_option('examples')
     subdir('examples')
 endif

--- a/reproc/meson_options.txt
+++ b/reproc/meson_options.txt
@@ -1,0 +1,2 @@
+option('multithread', type : 'boolean', value : true, description: 'Use pthread_sigmask and link against the system\'s thread library')
+option('examples', type : 'boolean', value : true, description: 'Request build of the examples')

--- a/reproc/meson_options.txt
+++ b/reproc/meson_options.txt
@@ -1,2 +1,0 @@
-option('multithread', type : 'boolean', value : true, description: 'Use pthread_sigmask and link against the system\'s thread library')
-option('examples', type : 'boolean', value : true, description: 'Request build of the examples')


### PR DESCRIPTION
Add a meson build config alongside to the cmake config.

The new meson config is supposed to be on par with the cmake one. I tested on Windows and Linux and it appear to works.

### Why a meson config ?

Meson is a modern free software build system widely used in many free software projects like Mesa 3D, Gnome and many others.

Compared to a cmake config meson is less obscure and complicated and some people may prefer it. Maintaining a meson build alongside the cmake one should be easy as the meson config is very simple.