### PR TITLE
allow stdin with 0 bytes

### DIFF
--- a/reproc/src/options.c
+++ b/reproc/src/options.c
@@ -113,10 +113,12 @@ int parse_options(reproc_options *options, const char *const *argv)
     return r;
   }
 
-  if (options->input.data != NULL || options->input.size > 0) {
-    ASSERT_EINVAL(options->input.data != NULL);
-    ASSERT_EINVAL(options->input.size > 0);
+  if (options->input.data != NULL) {
     ASSERT_EINVAL(options->redirect.in.type == REPROC_REDIRECT_PIPE);
+  }
+
+  if (options->input.size > 0) {
+    ASSERT_EINVAL(options->input.data != NULL);
   }
 
   if (options->fork) {

--- a/reproc/src/reproc.c
+++ b/reproc/src/reproc.c
@@ -49,8 +49,7 @@ const int REPROC_DEADLINE = -2;
 
 static int setup_input(pipe_type *pipe, const uint8_t *data, size_t size)
 {
-  if (data == NULL || size == 0) {
-    ASSERT(data == NULL);
+  if (data == NULL) {
     ASSERT(size == 0);
     return 0;
   }


### PR DESCRIPTION
Sending 0 bytes to stdin is not the same as not connecting to stdin at all, and should be supported.  By simply removing the (size > 0) checks, it seems to work fine at least on Linux.  I have not tried compiling on Windows.  