### PR TITLE
Fix _WIN32_WINNT macro redefinition warnings on MSVC

### DIFF
--- a/reproc/src/clock.windows.c
+++ b/reproc/src/clock.windows.c
@@ -1,4 +1,8 @@
-#define _WIN32_WINNT _WIN32_WINNT_VISTA
+#ifndef _WIN32_WINNT
+  #define _WIN32_WINNT 0x0600 // _WIN32_WINNT_VISTA
+#elif _WIN32_WINNT < 0x0600
+  #error "_WIN32_WINNT must be greater than _WIN32_WINNT_VISTA (0x0600)"
+#endif
 
 #include "clock.h"
 

--- a/reproc/src/error.windows.c
+++ b/reproc/src/error.windows.c
@@ -1,4 +1,8 @@
-#define _WIN32_WINNT _WIN32_WINNT_VISTA
+#ifndef _WIN32_WINNT
+  #define _WIN32_WINNT 0x0600 // _WIN32_WINNT_VISTA
+#elif _WIN32_WINNT < 0x0600
+  #error "_WIN32_WINNT must be greater than _WIN32_WINNT_VISTA (0x0600)"
+#endif
 
 #include "error.h"
 

--- a/reproc/src/handle.windows.c
+++ b/reproc/src/handle.windows.c
@@ -1,4 +1,8 @@
-#define _WIN32_WINNT _WIN32_WINNT_VISTA
+#ifndef _WIN32_WINNT
+  #define _WIN32_WINNT 0x0600 // _WIN32_WINNT_VISTA
+#elif _WIN32_WINNT < 0x0600
+  #error "_WIN32_WINNT must be greater than _WIN32_WINNT_VISTA (0x0600)"
+#endif
 
 #include "handle.h"
 

--- a/reproc/src/init.windows.c
+++ b/reproc/src/init.windows.c
@@ -1,4 +1,8 @@
-#define _WIN32_WINNT _WIN32_WINNT_VISTA
+#ifndef _WIN32_WINNT
+  #define _WIN32_WINNT 0x0600 // _WIN32_WINNT_VISTA
+#elif _WIN32_WINNT < 0x0600
+  #error "_WIN32_WINNT must be greater than _WIN32_WINNT_VISTA (0x0600)"
+#endif
 
 #include "init.h"
 

--- a/reproc/src/pipe.windows.c
+++ b/reproc/src/pipe.windows.c
@@ -1,4 +1,8 @@
-#define _WIN32_WINNT _WIN32_WINNT_VISTA
+#ifndef _WIN32_WINNT
+  #define _WIN32_WINNT 0x0600 // _WIN32_WINNT_VISTA
+#elif _WIN32_WINNT < 0x0600
+  #error "_WIN32_WINNT must be greater than _WIN32_WINNT_VISTA (0x0600)"
+#endif
 
 #include "pipe.h"
 

--- a/reproc/src/process.windows.c
+++ b/reproc/src/process.windows.c
@@ -1,4 +1,8 @@
-#define _WIN32_WINNT _WIN32_WINNT_VISTA
+#ifndef _WIN32_WINNT
+  #define _WIN32_WINNT 0x0600 // _WIN32_WINNT_VISTA
+#elif _WIN32_WINNT < 0x0600
+  #error "_WIN32_WINNT must be greater than _WIN32_WINNT_VISTA (0x0600)"
+#endif
 
 #include "process.h"
 

--- a/reproc/src/redirect.windows.c
+++ b/reproc/src/redirect.windows.c
@@ -1,4 +1,8 @@
-#define _WIN32_WINNT _WIN32_WINNT_VISTA
+#ifndef _WIN32_WINNT
+  #define _WIN32_WINNT 0x0600 // _WIN32_WINNT_VISTA
+#elif _WIN32_WINNT < 0x0600
+  #error "_WIN32_WINNT must be greater than _WIN32_WINNT_VISTA (0x0600)"
+#endif
 
 #include "redirect.h"
 


### PR DESCRIPTION
Windows project can be configured using the _WIN32_WINNT macro. This macro can be defined using the /D compiler option.  When using the precompiler definition and the selected warning level is at least 1, then macro redefinition warning (c4005) is produced by the compiler.

The ifndef block is able to detect if the macro symbol was already defined and ensures that the appropriate version of Windows was selected.

https://docs.microsoft.com/en-us/windows/win32/winprog/using-the-windows-headers
https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4005