### PR TITLE
Fix librt being linked unnecessarily

### DIFF
--- a/reproc/CMakeLists.txt
+++ b/reproc/CMakeLists.txt
@@ -1,6 +1,6 @@
 if(WIN32)
   set(REPROC_WINSOCK_LIBRARY ws2_32)
-elseif(NOT APPLE)
+elseif(CMAKE_SYSTEM_NAME MATCHES Linux)
   set(REPROC_RT_LIBRARY rt) # clock_gettime
 endif()
 


### PR DESCRIPTION
clock_gettime does not need librt on many platforms, except Linux. The commit makes librt only linked on Linux, solving #83.

The solution I proposed on #83 seemed to not work on Ubuntu, and it is fixed in my branch.
