### PR TITLE
reproc_strerror: avoid undefined behaviour for error == INT_MIN

### DIFF
--- a/reproc/src/error.posix.c
+++ b/reproc/src/error.posix.c
@@ -3,6 +3,7 @@
 #include "error.h"
 
 #include <errno.h>
+#include <limits.h>
 #include <stdlib.h>
 #include <string.h>
 
@@ -21,6 +22,9 @@ enum { ERROR_STRING_MAX_SIZE = 512 };
 const char *error_string(int error)
 {
   static THREAD_LOCAL char string[ERROR_STRING_MAX_SIZE];
+
+  if(error == INT_MIN)
+    return "Failed to retrieve error string";
 
   int r = strerror_r(abs(error), string, ARRAY_SIZE(string));
   if (r != 0) {

--- a/reproc/src/error.windows.c
+++ b/reproc/src/error.windows.c
@@ -28,6 +28,9 @@ const char *error_string(int error)
   wchar_t *wstring = NULL;
   int r = -1;
 
+  if(error == INT_MIN)
+    return "Failed to retrieve error string";
+
   wstring = malloc(sizeof(wchar_t) * ERROR_STRING_MAX_SIZE);
   if (wstring == NULL) {
     return "Failed to allocate memory for error string";


### PR DESCRIPTION
Invoking `abs` on the minimum integer has undefined behaviour. Catch this case before calling `abs` and return an error message instead.