### PR TITLE
Bump project to version 14.2.8

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.12...3.21)
 
 project(
   reproc
-  VERSION 14.2.7
+  VERSION 14.2.8
   DESCRIPTION "Cross-platform C99/C++11 process library"
   HOMEPAGE_URL "https://github.com/DaanDeMeyer/reproc"
   LANGUAGES C


### PR DESCRIPTION
Release [`v14.2.8`](https://github.com/daandemeyer/reproc/releases/tag/14.2.8) does not include the version bump of the project.

The release should be re-issued after this PR is merged